### PR TITLE
Port improvements from simple-monerod-docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .git
 .github
 README.md
-config/
 docker-compose.yml
 docker-compose.override.yml
 docker-compose.override.yml.example

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,11 +13,14 @@ on:
     paths:
       - 'Dockerfile'
       - 'docker-compose.yml'
+      - 'config/Cuprated.toml'
       - '.github/workflows/docker-build.yml'
 
+# Never run two prod pushes for the same ref concurrently (avoid racing the
+# manifest/`latest` tag); do not cancel an in-flight push.
 concurrency:
   group: docker-build-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check-upstream-tag:
@@ -29,17 +32,23 @@ jobs:
       should_build: ${{ steps.check-image.outputs.should_build }}
       version: ${{ steps.get-latest-tag.outputs.version }}
       cuprate_tag: ${{ steps.get-latest-tag.outputs.cuprate_tag }}
+      cuprate_commit: ${{ steps.get-latest-tag.outputs.cuprate_commit }}
     steps:
       - name: Get latest Cuprate tag
         id: get-latest-tag
         run: |
-          # Fetch the latest tag from Cuprate repository that matches the pattern
-          LATEST_TAG=$(curl -s https://api.github.com/repos/cuprate/cuprate/tags | jq -r '[.[] | select(.name | startswith("cuprated-"))] | .[0].name')
-          echo "Latest Cuprate tag: $LATEST_TAG"
+          # Fetch the latest tag from the Cuprate repository that matches the
+          # pattern (GitHub's tags API returns most-recent first) together
+          # with the commit it points at, so the build can be pinned to it.
+          TAG_INFO="$(curl -s https://api.github.com/repos/cuprate/cuprate/tags | jq -c '[.[] | select(.name | startswith("cuprated-"))] | .[0] | {name, commit: .commit.sha}')"
+          LATEST_TAG="$(jq -r '.name' <<< "${TAG_INFO}")"
+          LATEST_SHA="$(jq -r '.commit' <<< "${TAG_INFO}")"
+          echo "Latest Cuprate tag: ${LATEST_TAG} (commit ${LATEST_SHA})"
           # Extract version number from tag (e.g., cuprated-0.0.1 -> 0.0.1)
           VERSION=${LATEST_TAG#cuprated-}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "cuprate_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "cuprate_commit=$LATEST_SHA" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -87,6 +96,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Fetch all history for better versioning
+          persist-credentials: false
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
@@ -120,7 +130,7 @@ jobs:
       - name: Get build date
         id: build-date
         run: echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
-        
+
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -131,6 +141,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CUPRATE_TAG=${{ needs.check-upstream-tag.outputs.cuprate_tag }}
+            CUPRATE_COMMIT_HASH=${{ needs.check-upstream-tag.outputs.cuprate_commit }}
             BUILD_DATE=${{ steps.build-date.outputs.date }}
             VCS_REF=${{ github.sha }}
             VERSION=${{ needs.check-upstream-tag.outputs.version }}
@@ -146,6 +157,43 @@ jobs:
           # as platform variants and corrupt the multi-arch manifest list.
           provenance: false
           sbom: false
+
+      # Smoke-test the exact artifact that was just pushed, BEFORE the merge job
+      # tags it `latest`. If either check fails here, merge-manifests (needs: build-arch)
+      # never runs, so a broken image can never be promoted.
+      - name: Verify pushed image reports the pinned Cuprate commit
+        run: |
+          set -euo pipefail
+          EXPECTED_COMMIT="${{ needs.check-upstream-tag.outputs.cuprate_commit }}"
+          IMG="ghcr.io/${{ github.repository_owner }}/cuprate-docker:${{ needs.check-upstream-tag.outputs.version }}-${{ matrix.suffix }}"
+          echo "Expecting commit ${EXPECTED_COMMIT} from ${IMG}"
+          OUT="$(docker run --rm "${IMG}" --version || true)"
+          echo "${OUT}"
+          echo "${OUT}" | jq -e --arg want "${EXPECTED_COMMIT}" '.commit == $want' >/dev/null \
+            || { echo "::error::pushed image commit mismatch (expected ${EXPECTED_COMMIT})"; exit 1; }
+
+      - name: Verify pushed image reaches a healthy state
+        run: |
+          set -uo pipefail
+          IMG="ghcr.io/${{ github.repository_owner }}/cuprate-docker:${{ needs.check-upstream-tag.outputs.version }}-${{ matrix.suffix }}"
+          CID="$(docker run -d "${IMG}")"
+          status="starting"
+          for i in $(seq 1 80); do
+            status="$(docker inspect -f '{{.State.Health.Status}}' "$CID" 2>/dev/null || echo gone)"
+            echo "attempt ${i}: health=${status}"
+            case "${status}" in
+              healthy) break ;;
+              unhealthy|gone)
+                echo "::error::pushed image became ${status}"; docker logs "$CID" || true
+                docker rm -f "$CID" >/dev/null 2>&1 || true; exit 1 ;;
+            esac
+            sleep 5
+          done
+          if [ "${status}" != "healthy" ]; then
+            echo "::error::pushed image healthcheck did not pass within timeout"; docker logs "$CID" || true
+            docker rm -f "$CID" >/dev/null 2>&1 || true; exit 1
+          fi
+          docker rm -f "$CID" >/dev/null 2>&1 || true
 
   merge-manifests:
     needs: [check-upstream-tag, build-arch]

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'Dockerfile'
       - 'docker-compose.yml'
+      - 'config/Cuprated.toml'
       - '.github/workflows/**'
 
 concurrency:
@@ -20,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -29,8 +32,42 @@ jobs:
         with:
           context: .
           push: false
+          load: true
+          tags: cuprate-docker:testing
           platforms: linux/amd64
           cache-from: |
             type=gha,scope=build-amd64
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/cuprate-docker:buildcache-amd64
           cache-to: type=gha,mode=max,scope=build-amd64
+
+      - name: Verify built binary reports the pinned Cuprate commit
+        run: |
+          set -euo pipefail
+          EXPECTED_COMMIT="$(awk -F= '/^ARG CUPRATE_COMMIT_HASH=/{print $2; exit}' Dockerfile)"
+          echo "Expecting commit: ${EXPECTED_COMMIT}"
+          OUT="$(docker run --rm cuprate-docker:testing --version || true)"
+          echo "${OUT}"
+          echo "${OUT}" | jq -e --arg want "${EXPECTED_COMMIT}" '.commit == $want' >/dev/null \
+            || { echo "::error::built image commit does not match pinned CUPRATE_COMMIT_HASH"; exit 1; }
+
+      - name: Verify the built image reaches a healthy state
+        run: |
+          set -uo pipefail
+          CID="$(docker run -d cuprate-docker:testing)"
+          status="starting"
+          for i in $(seq 1 80); do
+            status="$(docker inspect -f '{{.State.Health.Status}}' "$CID" 2>/dev/null || echo gone)"
+            echo "attempt ${i}: health=${status}"
+            case "${status}" in
+              healthy) break ;;
+              unhealthy|gone)
+                echo "::error::container became ${status}"; docker logs "$CID" || true
+                docker rm -f "$CID" >/dev/null 2>&1 || true; exit 1 ;;
+            esac
+            sleep 5
+          done
+          if [ "${status}" != "healthy" ]; then
+            echo "::error::healthcheck did not pass within timeout"; docker logs "$CID" || true
+            docker rm -f "$CID" >/dev/null 2>&1 || true; exit 1
+          fi
+          docker rm -f "$CID" >/dev/null 2>&1 || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,13 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Cuprate release tag / branch to build
+# renovate: datasource=github-releases depName=Cuprate/cuprate
 ARG CUPRATE_TAG=cuprated-0.1.0-preview
+# The exact commit CUPRATE_TAG must resolve to. Pinning this hash means a moved or
+# force-pushed upstream tag fails the build instead of silently producing a
+# different binary. Always bump this in lockstep with CUPRATE_TAG.
+# Only skipped when CUPRATE_TAG=main (a moving branch that cannot be pinned).
+ARG CUPRATE_COMMIT_HASH=318c2dea4eb404ac4ecf2bea87c1a4696b0198cc
 # Allocator feature (matches upstream Docker default)
 ARG FEATURES=jemalloc
 
@@ -18,7 +24,9 @@ RUN git clone https://github.com/Cuprate/cuprate.git && \
     cd cuprate && \
     if [ "$CUPRATE_TAG" != "main" ]; then \
         git fetch --all --tags && \
-        git checkout ${CUPRATE_TAG}; \
+        git checkout ${CUPRATE_TAG} && \
+        test "$(git rev-parse HEAD)" = "${CUPRATE_COMMIT_HASH}" || \
+            { echo "error: ${CUPRATE_TAG} resolves to $(git rev-parse HEAD), expected ${CUPRATE_COMMIT_HASH}" >&2; exit 1; }; \
     fi
 WORKDIR /usr/src/cuprate
 
@@ -61,6 +69,10 @@ RUN mkdir -p /home/cuprate/.local/share/cuprate \
 
 # Copy the binary from the builder stage
 COPY --from=builder /usr/local/bin/cuprated /usr/local/bin/
+
+# Ship a default config so the image works standalone (e.g. CI smoke tests).
+# A bind-mounted ./config (as in docker-compose.yml) shadows this path and wins.
+COPY --chown=cuprate:cuprate config/Cuprated.toml /home/cuprate/.config/cuprate/Cuprated.toml
 
 # Set the user
 USER cuprate

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Compatible with **cuprated 0.1.0-preview (Kesterite)** — initial wallet RPC su
 
 - Multi-architecture images (`linux/amd64` and `linux/arm64`)
 - Automated builds — new upstream Cuprate releases are detected and built every 8 hours
+- Builds pinned to the exact upstream commit — a moved or force-pushed tag fails the build instead of changing what ships
+- CI smoke-tests every image (binary commit + healthcheck) before it is tagged `latest`
 - Built with `jemalloc` (same default as upstream Docker)
 - Healthcheck via restricted RPC endpoint
 - Resource limits (4 GB memory limit in Docker Compose) and log rotation pre-configured
@@ -101,6 +103,8 @@ docker compose up -d
 | `cuprate-data` (Docker volume) | `/home/cuprate/.local/share/cuprate` | Blockchain database |
 | `./config` (bind mount) | `/home/cuprate/.config/cuprate` | Configuration files |
 
+The image also ships a copy of the default config at `/home/cuprate/.config/cuprate/Cuprated.toml`, so it works standalone without any mount. A bind-mounted `./config` (as in `docker-compose.yml`) shadows that copy.
+
 ## Ports
 
 | Network | P2P | Restricted RPC |
@@ -110,6 +114,19 @@ docker compose up -d
 | Stagenet | 38080 | 38089 |
 
 Only mainnet ports are mapped by default. See `docker-compose.override.yml.example` for testnet/stagenet.
+
+## Security: Docker port publishing (0.0.0.0) and UFW
+
+Docker publishes ports on all interfaces by default. If you define `ports:` in `docker-compose.yml` (for example `- 18089:18089`), Docker binds those ports to `0.0.0.0` unless you explicitly specify a host IP, making them reachable from any network interface on the host.
+
+This can also bypass UFW rules. Docker installs its own iptables rules that accept traffic to published ports before UFW's filter rules are evaluated, so even a default-deny firewall does not stop a published port from being reachable from the internet.
+
+- The restricted RPC (`18089`) is enabled by default in this image (`rpc.restricted.enable = true`). If you do not want it exposed publicly, either do not publish it at all or bind it only to localhost:
+  - `docker-compose.yml`: `ports: ["127.0.0.1:18089:18089"]`
+- For a public P2P node, it is normal to publish `18080`. Be deliberate about whether `18089` (restricted RPC) should be public.
+- If you are running this container behind a firewall (e.g. at home behind a NAT router), it is usually okay to bind on `0.0.0.0`.
+
+The unrestricted RPC (`18081`) is only bound to `127.0.0.1` inside the container and is never published by default.
 
 ## CLI Options
 
@@ -142,12 +159,19 @@ docker run --rm ghcr.io/hundehausen/cuprate-docker:latest --version
 # Build with default tag (cuprated-0.1.0-preview)
 docker build -t cuprate-docker:local .
 
-# Build a specific Cuprate version
+# Build a specific Cuprate version (pinned to its commit hash)
 docker build -t cuprate-docker:local \
   --build-arg CUPRATE_TAG=cuprated-0.1.0-preview \
   .
 
-# Build latest development version
+# Build a specific Cuprate version with an explicit commit hash
+# (PINNED_COMMIT must be the commit CUPRATE_TAG resolves to)
+docker build -t cuprate-docker:local \
+  --build-arg CUPRATE_TAG=cuprated-0.1.0-preview \
+  --build-arg CUPRATE_COMMIT_HASH=318c2dea4eb404ac4ecf2bea87c1a4696b0198cc \
+  .
+
+# Build latest development version (moving branch, pin check skipped)
 docker build -t cuprate-docker:local \
   --build-arg CUPRATE_TAG=main \
   .
@@ -157,6 +181,8 @@ docker build -t cuprate-docker:local \
   --build-arg FEATURES=jemalloc \
   .
 ```
+
+The build verifies that `CUPRATE_TAG` resolves to `CUPRATE_COMMIT_HASH` and fails if they disagree — a moved or force-pushed upstream tag can never silently change what gets built. The exception is `CUPRATE_TAG=main`, which points at a moving branch and is not pinned. The default tag and hash are kept in lockstep in the `Dockerfile`.
 
 You can also use the compose override to build locally instead of pulling from GHCR — see `docker-compose.override.yml.example`.
 

--- a/config/Cuprated.toml
+++ b/config/Cuprated.toml
@@ -76,7 +76,7 @@ level = "info"
 ##
 ## Type         | Level
 ## Valid values | "error", "warn", "info", "debug", "trace"
-level = "debug"
+level = "info"
 ## The maximum amount of log files to keep.
 ##
 ## Once this number is passed the oldest file will be deleted.

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -14,6 +14,7 @@ services:
     #   dockerfile: Dockerfile
     #   args:
     #     CUPRATE_TAG: cuprated-0.1.0-preview
+    #     # CUPRATE_COMMIT_HASH: <commit CUPRATE_TAG resolves to>  # optional; default matches the default tag
     #     FEATURES: jemalloc
 
     ## Uncomment for testnet


### PR DESCRIPTION
- Pin upstream builds to the exact commit (CUPRATE_COMMIT_HASH): the checked-out HEAD must match, so a moved/force-pushed tag fails the build instead of silently shipping a different binary. CI passes the tag's commit fetched from the GitHub tags API and verifies the built binary reports it.
- Bake the default config into the image so it runs standalone (CI smoke tests, bare docker run); the compose bind-mount still shadows it.
- CI smoke tests (ported from build-image-on-push.yml): PR builds and each pushed per-arch image are booted and must reach healthy before merge-manifests tags the result 'latest'.
- Do not cancel an in-flight prod push (prevents racing the latest tag).
- Carry over monerod's Docker port-publishing/UFW security note to the README.

Let me know if you want me to drop any of these from the PR, happy to accomodate but thought you might want some of the additions/improvements/hardening I've been doing on my own repo!