### PR TITLE
Harden container runtime (read-only rootfs, cap-drop, ro config mount) and limit log amplification

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .git
 .github
 README.md
-config/
 docker-compose.yml
 docker-compose.override.yml
 docker-compose.override.yml.example

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,11 +13,14 @@ on:
     paths:
       - 'Dockerfile'
       - 'docker-compose.yml'
+      - 'config/Cuprated.toml'
       - '.github/workflows/docker-build.yml'
 
+# Never run two prod pushes for the same ref concurrently (avoid racing the
+# manifest/`latest` tag); do not cancel an in-flight push.
 concurrency:
   group: docker-build-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check-upstream-tag:
@@ -29,17 +32,23 @@ jobs:
       should_build: ${{ steps.check-image.outputs.should_build }}
       version: ${{ steps.get-latest-tag.outputs.version }}
       cuprate_tag: ${{ steps.get-latest-tag.outputs.cuprate_tag }}
+      cuprate_commit: ${{ steps.get-latest-tag.outputs.cuprate_commit }}
     steps:
       - name: Get latest Cuprate tag
         id: get-latest-tag
         run: |
-          # Fetch the latest tag from Cuprate repository that matches the pattern
-          LATEST_TAG=$(curl -s https://api.github.com/repos/cuprate/cuprate/tags | jq -r '[.[] | select(.name | startswith("cuprated-"))] | .[0].name')
-          echo "Latest Cuprate tag: $LATEST_TAG"
+          # Fetch the latest tag from the Cuprate repository that matches the
+          # pattern (GitHub's tags API returns most-recent first) together
+          # with the commit it points at, so the build can be pinned to it.
+          TAG_INFO="$(curl -s https://api.github.com/repos/cuprate/cuprate/tags | jq -c '[.[] | select(.name | startswith("cuprated-"))] | .[0] | {name, commit: .commit.sha}')"
+          LATEST_TAG="$(jq -r '.name' <<< "${TAG_INFO}")"
+          LATEST_SHA="$(jq -r '.commit' <<< "${TAG_INFO}")"
+          echo "Latest Cuprate tag: ${LATEST_TAG} (commit ${LATEST_SHA})"
           # Extract version number from tag (e.g., cuprated-0.0.1 -> 0.0.1)
           VERSION=${LATEST_TAG#cuprated-}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "cuprate_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "cuprate_commit=$LATEST_SHA" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -87,6 +96,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Fetch all history for better versioning
+          persist-credentials: false
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
@@ -120,7 +130,7 @@ jobs:
       - name: Get build date
         id: build-date
         run: echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
-        
+
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -131,6 +141,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CUPRATE_TAG=${{ needs.check-upstream-tag.outputs.cuprate_tag }}
+            CUPRATE_COMMIT_HASH=${{ needs.check-upstream-tag.outputs.cuprate_commit }}
             BUILD_DATE=${{ steps.build-date.outputs.date }}
             VCS_REF=${{ github.sha }}
             VERSION=${{ needs.check-upstream-tag.outputs.version }}
@@ -146,6 +157,43 @@ jobs:
           # as platform variants and corrupt the multi-arch manifest list.
           provenance: false
           sbom: false
+
+      # Smoke-test the exact artifact that was just pushed, BEFORE the merge job
+      # tags it `latest`. If either check fails here, merge-manifests (needs: build-arch)
+      # never runs, so a broken image can never be promoted.
+      - name: Verify pushed image reports the pinned Cuprate commit
+        run: |
+          set -euo pipefail
+          EXPECTED_COMMIT="${{ needs.check-upstream-tag.outputs.cuprate_commit }}"
+          IMG="ghcr.io/${{ github.repository_owner }}/cuprate-docker:${{ needs.check-upstream-tag.outputs.version }}-${{ matrix.suffix }}"
+          echo "Expecting commit ${EXPECTED_COMMIT} from ${IMG}"
+          OUT="$(docker run --rm "${IMG}" --version || true)"
+          echo "${OUT}"
+          echo "${OUT}" | jq -e --arg want "${EXPECTED_COMMIT}" '.commit == $want' >/dev/null \
+            || { echo "::error::pushed image commit mismatch (expected ${EXPECTED_COMMIT})"; exit 1; }
+
+      - name: Verify pushed image reaches a healthy state
+        run: |
+          set -uo pipefail
+          IMG="ghcr.io/${{ github.repository_owner }}/cuprate-docker:${{ needs.check-upstream-tag.outputs.version }}-${{ matrix.suffix }}"
+          CID="$(docker run -d "${IMG}")"
+          status="starting"
+          for i in $(seq 1 80); do
+            status="$(docker inspect -f '{{.State.Health.Status}}' "$CID" 2>/dev/null || echo gone)"
+            echo "attempt ${i}: health=${status}"
+            case "${status}" in
+              healthy) break ;;
+              unhealthy|gone)
+                echo "::error::pushed image became ${status}"; docker logs "$CID" || true
+                docker rm -f "$CID" >/dev/null 2>&1 || true; exit 1 ;;
+            esac
+            sleep 5
+          done
+          if [ "${status}" != "healthy" ]; then
+            echo "::error::pushed image healthcheck did not pass within timeout"; docker logs "$CID" || true
+            docker rm -f "$CID" >/dev/null 2>&1 || true; exit 1
+          fi
+          docker rm -f "$CID" >/dev/null 2>&1 || true
 
   merge-manifests:
     needs: [check-upstream-tag, build-arch]

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'Dockerfile'
       - 'docker-compose.yml'
+      - 'config/Cuprated.toml'
       - '.github/workflows/**'
 
 concurrency:
@@ -20,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -29,8 +32,42 @@ jobs:
         with:
           context: .
           push: false
+          load: true
+          tags: cuprate-docker:testing
           platforms: linux/amd64
           cache-from: |
             type=gha,scope=build-amd64
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/cuprate-docker:buildcache-amd64
           cache-to: type=gha,mode=max,scope=build-amd64
+
+      - name: Verify built binary reports the pinned Cuprate commit
+        run: |
+          set -euo pipefail
+          EXPECTED_COMMIT="$(awk -F= '/^ARG CUPRATE_COMMIT_HASH=/{print $2; exit}' Dockerfile)"
+          echo "Expecting commit: ${EXPECTED_COMMIT}"
+          OUT="$(docker run --rm cuprate-docker:testing --version || true)"
+          echo "${OUT}"
+          echo "${OUT}" | jq -e --arg want "${EXPECTED_COMMIT}" '.commit == $want' >/dev/null \
+            || { echo "::error::built image commit does not match pinned CUPRATE_COMMIT_HASH"; exit 1; }
+
+      - name: Verify the built image reaches a healthy state
+        run: |
+          set -uo pipefail
+          CID="$(docker run -d cuprate-docker:testing)"
+          status="starting"
+          for i in $(seq 1 80); do
+            status="$(docker inspect -f '{{.State.Health.Status}}' "$CID" 2>/dev/null || echo gone)"
+            echo "attempt ${i}: health=${status}"
+            case "${status}" in
+              healthy) break ;;
+              unhealthy|gone)
+                echo "::error::container became ${status}"; docker logs "$CID" || true
+                docker rm -f "$CID" >/dev/null 2>&1 || true; exit 1 ;;
+            esac
+            sleep 5
+          done
+          if [ "${status}" != "healthy" ]; then
+            echo "::error::healthcheck did not pass within timeout"; docker logs "$CID" || true
+            docker rm -f "$CID" >/dev/null 2>&1 || true; exit 1
+          fi
+          docker rm -f "$CID" >/dev/null 2>&1 || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,13 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Cuprate release tag / branch to build
+# renovate: datasource=github-releases depName=Cuprate/cuprate
 ARG CUPRATE_TAG=cuprated-0.1.0-preview
+# The exact commit CUPRATE_TAG must resolve to. Pinning this hash means a moved or
+# force-pushed upstream tag fails the build instead of silently producing a
+# different binary. Always bump this in lockstep with CUPRATE_TAG.
+# Only skipped when CUPRATE_TAG=main (a moving branch that cannot be pinned).
+ARG CUPRATE_COMMIT_HASH=318c2dea4eb404ac4ecf2bea87c1a4696b0198cc
 # Allocator feature (matches upstream Docker default)
 ARG FEATURES=jemalloc
 
@@ -18,7 +24,9 @@ RUN git clone https://github.com/Cuprate/cuprate.git && \
     cd cuprate && \
     if [ "$CUPRATE_TAG" != "main" ]; then \
         git fetch --all --tags && \
-        git checkout ${CUPRATE_TAG}; \
+        git checkout ${CUPRATE_TAG} && \
+        test "$(git rev-parse HEAD)" = "${CUPRATE_COMMIT_HASH}" || \
+            { echo "error: ${CUPRATE_TAG} resolves to $(git rev-parse HEAD), expected ${CUPRATE_COMMIT_HASH}" >&2; exit 1; }; \
     fi
 WORKDIR /usr/src/cuprate
 
@@ -61,6 +69,10 @@ RUN mkdir -p /home/cuprate/.local/share/cuprate \
 
 # Copy the binary from the builder stage
 COPY --from=builder /usr/local/bin/cuprated /usr/local/bin/
+
+# Ship a default config so the image works standalone (e.g. CI smoke tests).
+# A bind-mounted ./config (as in docker-compose.yml) shadows this path and wins.
+COPY --chown=cuprate:cuprate config/Cuprated.toml /home/cuprate/.config/cuprate/Cuprated.toml
 
 # Set the user
 USER cuprate

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,15 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates wget && \
     rm -rf /var/lib/apt/lists/*
 
+# Defense-in-depth: Debian's base image ships setuid-root helpers (mount(8),
+# su(1), passwd(1), ...). The node runs as a non-privileged user with all
+# capabilities dropped and no-new-privileges enforced at deploy time (see
+# docker-compose.yml), but remove the bits anyway so no helper in the image can
+# ever be used to gain root after a compromise. chmod, not delete, so packages
+# keep their files intact.
+RUN find / -xdev -type f -perm /4000 -exec chmod u-s {} + && \
+    find / -xdev -type f -perm /2000 -exec chmod g-s {} +
+
 # Create a cuprate user
 RUN useradd -m -u 1000 -s /usr/sbin/nologin cuprate
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Compatible with **cuprated 0.1.0-preview (Kesterite)** — initial wallet RPC su
 - Built with `jemalloc` (same default as upstream Docker)
 - Healthcheck via restricted RPC endpoint
 - Resource limits (4 GB memory limit in Docker Compose) and log rotation pre-configured
+- Hardened Docker Compose runtime by default: read-only root filesystem, all Linux capabilities dropped, `no-new-privileges`, read-only config mount, bounded process/swap limits (see [Security hardening](#security-hardening))
 - Mainnet, testnet, stagenet, and FakeChain/regtest support
 
 ## Quick Start
@@ -51,12 +52,14 @@ docker run -d \
   --name cuprate-node \
   -t -i \
   -v cuprate-data:/home/cuprate/.local/share/cuprate \
-  -v ./config:/home/cuprate/.config/cuprate \
+  -v ./config:/home/cuprate/.config/cuprate:ro \
   -p 18080:18080 \
   -p 18089:18089 \
   ghcr.io/hundehausen/cuprate-docker:latest \
   --config-file /home/cuprate/.config/cuprate/Cuprated.toml
 ```
+
+The Compose file applies additional hardening flags (`--read-only`, `--cap-drop=ALL`, `--security-opt no-new-privileges`, `--pids-limit`, `--memory-swap`); add the equivalent `docker run` flags if you run without Compose.
 
 ### Verify it's running
 
@@ -86,6 +89,10 @@ Key defaults:
 | `rpc.unrestricted.enable` | `true` | Unrestricted RPC on `127.0.0.1:18081` (container-local only by default) |
 | `target_max_memory` | auto-detected | Target max memory usage in bytes (auto-detected from system RAM) |
 
+### Logging
+
+`cuprated` writes a second, file-based log stream to `<data dir>/logs/` — i.e. inside the `cuprate-data` volume, which lives on the Docker host's disk. The shipped config keeps the **file** log level at `info` (not `debug`) and rotates **daily** with `max_log_files = 7`, so at most seven daily files exist. Each individual file is unbounded in size, and a fresh mainnet sync writes several GB of logs on its own, so keep an eye on the volume if you run a busy node. HTTP requests are only logged at `debug` level, so traffic against the public restricted RPC does not amplify disk writes.
+
 ### Network Selection
 
 By default the node runs on mainnet. For testnet, stagenet, offline mode, or regtest, copy the override example and uncomment the section you need:
@@ -100,8 +107,8 @@ docker compose up -d
 
 | Volume/Mount | Container Path | Description |
 |---|---|---|
-| `cuprate-data` (Docker volume) | `/home/cuprate/.local/share/cuprate` | Blockchain database |
-| `./config` (bind mount) | `/home/cuprate/.config/cuprate` | Configuration files |
+| `cuprate-data` (Docker volume) | `/home/cuprate/.local/share/cuprate` | Blockchain database and logs |
+| `./config` (bind mount, **read-only**) | `/home/cuprate/.config/cuprate` | Configuration files |
 
 The image also ships a copy of the default config at `/home/cuprate/.config/cuprate/Cuprated.toml`, so it works standalone without any mount. A bind-mounted `./config` (as in `docker-compose.yml`) shadows that copy.
 
@@ -127,6 +134,23 @@ This can also bypass UFW rules. Docker installs its own iptables rules that acce
 - If you are running this container behind a firewall (e.g. at home behind a NAT router), it is usually okay to bind on `0.0.0.0`.
 
 The unrestricted RPC (`18081`) is only bound to `127.0.0.1` inside the container and is never published by default.
+
+## Security: hardened container runtime
+
+The container runs as a non-root user (`cuprate`, uid 1000 — the same uid as many host users, so treat anything mounted writable as host-writable). To contain a compromised node, the default `docker-compose.yml` enforces:
+
+| Limit | Effect |
+|-------|--------|
+| `read_only: true` + tmpfs for `/tmp` and the cache dir | root filesystem cannot be modified; writes go only to the data volume or to ephemeral tmpfs. The cache (peer address book, etc.) is deliberately in RAM — Cuprate documents it as safely deletable — and is re-built on restart |
+| `./config` mounted `:ro` | the container user cannot write through the bind mount into the host's `config/` directory |
+| `cap_drop: [ALL]` | cuprated needs no Linux capabilities (it binds ports above 1024); drops all of them |
+| `security_opt: no-new-privileges` | setuid/setgid helpers cannot elevate privileges, even ones present in the base image |
+| `pids_limit: 512` | bounds processes/threads as a backstop against fork/connection storms |
+| `memswap_limit: 4G` (equal to the memory limit) | a memory-pressure attack cannot spill the node's working set into host swap (Docker would otherwise allow 2x the memory limit) |
+
+The image itself is hardened too: the runtime stage strips the setuid/setgid bits from Debian's helper binaries (`mount`, `su`, `passwd`, ...) and runs with the distroless-like principle of only `cuprated` + `wget` (healthcheck) + CA certificates.
+
+These limits apply to the Compose deployment. A bare `docker run` (as in [Quick Start](#quick-start)) only gets what you pass on the command line, so prefer `docker compose up -d` for anything facing a network.
 
 ## CLI Options
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Compatible with **cuprated 0.1.0-preview (Kesterite)** — initial wallet RPC su
 
 - Multi-architecture images (`linux/amd64` and `linux/arm64`)
 - Automated builds — new upstream Cuprate releases are detected and built every 8 hours
+- Builds pinned to the exact upstream commit — a moved or force-pushed tag fails the build instead of changing what ships
+- CI smoke-tests every image (binary commit + healthcheck) before it is tagged `latest`
 - Built with `jemalloc` (same default as upstream Docker)
 - Healthcheck via restricted RPC endpoint
 - Resource limits (4 GB memory limit in Docker Compose) and log rotation pre-configured
@@ -101,6 +103,8 @@ docker compose up -d
 | `cuprate-data` (Docker volume) | `/home/cuprate/.local/share/cuprate` | Blockchain database |
 | `./config` (bind mount) | `/home/cuprate/.config/cuprate` | Configuration files |
 
+The image also ships a copy of the default config at `/home/cuprate/.config/cuprate/Cuprated.toml`, so it works standalone without any mount. A bind-mounted `./config` (as in `docker-compose.yml`) shadows that copy.
+
 ## Ports
 
 | Network | P2P | Restricted RPC |
@@ -110,6 +114,19 @@ docker compose up -d
 | Stagenet | 38080 | 38089 |
 
 Only mainnet ports are mapped by default. See `docker-compose.override.yml.example` for testnet/stagenet.
+
+## Security: Docker port publishing (0.0.0.0) and UFW
+
+Docker publishes ports on all interfaces by default. If you define `ports:` in `docker-compose.yml` (for example `- 18089:18089`), Docker binds those ports to `0.0.0.0` unless you explicitly specify a host IP, making them reachable from any network interface on the host.
+
+This can also bypass UFW rules. Docker installs its own iptables rules that accept traffic to published ports before UFW's filter rules are evaluated, so even a default-deny firewall does not stop a published port from being reachable from the internet.
+
+- The restricted RPC (`18089`) is enabled by default in this image (`rpc.restricted.enable = true`). If you do not want it exposed publicly, either do not publish it at all or bind it only to localhost:
+  - `docker-compose.yml`: `ports: ["127.0.0.1:18089:18089"]`
+- For a public P2P node, it is normal to publish `18080`. Be deliberate about whether `18089` (restricted RPC) should be public.
+- If you are running this container behind a firewall (e.g. at home behind a NAT router), it is usually okay to bind on `0.0.0.0`.
+
+The unrestricted RPC (`18081`) is only bound to `127.0.0.1` inside the container and is never published by default.
 
 ## CLI Options
 
@@ -142,12 +159,19 @@ docker run --rm ghcr.io/hundehausen/cuprate-docker:latest --version
 # Build with default tag (cuprated-0.1.0-preview)
 docker build -t cuprate-docker:local .
 
-# Build a specific Cuprate version
+# Build a specific Cuprate version (pinned to its commit hash)
 docker build -t cuprate-docker:local \
   --build-arg CUPRATE_TAG=cuprated-0.1.0-preview \
   .
 
-# Build latest development version
+# Build a specific Cuprate version with an explicit commit hash
+# (PINNED_COMMIT must be the commit CUPRATE_TAG resolves to)
+docker build -t cuprate-docker:local \
+  --build-arg CUPRATE_TAG=cuprated-0.1.0-preview \
+  --build-arg CUPRATE_COMMIT_HASH=318c2dea4eb404ac4ecf2bea87c1a4696b0198cc \
+  .
+
+# Build latest development version (moving branch, pin check skipped)
 docker build -t cuprate-docker:local \
   --build-arg CUPRATE_TAG=main \
   .
@@ -157,6 +181,8 @@ docker build -t cuprate-docker:local \
   --build-arg FEATURES=jemalloc \
   .
 ```
+
+The build verifies that `CUPRATE_TAG` resolves to `CUPRATE_COMMIT_HASH` and fails if they disagree — a moved or force-pushed upstream tag can never silently change what gets built. The exception is `CUPRATE_TAG=main`, which points at a moving branch and is not pinned. The default tag and hash are kept in lockstep in the `Dockerfile`.
 
 You can also use the compose override to build locally instead of pulling from GHCR — see `docker-compose.override.yml.example`.
 

--- a/config/Cuprated.toml
+++ b/config/Cuprated.toml
@@ -76,7 +76,7 @@ level = "info"
 ##
 ## Type         | Level
 ## Valid values | "error", "warn", "info", "debug", "trace"
-level = "debug"
+level = "info"
 ## The maximum amount of log files to keep.
 ##
 ## Once this number is passed the oldest file will be deleted.

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -14,6 +14,7 @@ services:
     #   dockerfile: Dockerfile
     #   args:
     #     CUPRATE_TAG: cuprated-0.1.0-preview
+    #     # CUPRATE_COMMIT_HASH: <commit CUPRATE_TAG resolves to>  # optional; default matches the default tag
     #     FEATURES: jemalloc
 
     ## Uncomment for testnet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,38 @@ services:
       # - "38089:38089" # stagenet
     volumes:
       - cuprate-data:/home/cuprate/.local/share/cuprate
-      - ./config:/home/cuprate/.config/cuprate
+      # Mount the config read-only: the container user (uid 1000) matches a
+      # common host uid, and a writable bind mount would let a compromised
+      # node write straight to the host directory. Read-only still lets the
+      # node read its config (it never writes it back).
+      - ./config:/home/cuprate/.config/cuprate:ro
+    # The node only needs to write to its data volume and cache.
+    # A read-only root filesystem (plus tmpfs below) means a compromise cannot
+    # plant files on the host-backed layer, only in ephemeral tmpfs.
+    read_only: true
+    tmpfs:
+      - /tmp
+      # Owned by the cuprate user (uid/gid 1000) so the node can write its cache;
+      # bounded so it can only ever hold 64MB of the memory budget.
+      - /home/cuprate/.cache/cuprate:size=64m,uid=1000,gid=1000,mode=700
+    # cuprated needs no Linux capabilities (it binds ports > 1024) and
+    # never elevates privileges; drop them all.
+    cap_drop:
+      - ALL
+    # With no-new-privileges, the setuid-root helpers removed from the image
+    # cannot be re-enabled even if an attacker finds a setuid binary elsewhere.
+    security_opt:
+      - no-new-privileges:true
+    # Cap total memory+swap at the same value so a memory-pressure attack cannot
+    # spill the node's working set into host swap. Docker would otherwise allow
+    # 2x the memory limit in swap (8G on a 4G-limit node).
+    memswap_limit: 4G
     deploy:
       resources:
         limits:
           memory: 4G
+          # Bound the process count as a cheap backstop against fork/connection storms.
+          pids: 512
     logging:
       driver: json-file
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,16 +36,19 @@ services:
     # cannot be re-enabled even if an attacker finds a setuid binary elsewhere.
     security_opt:
       - no-new-privileges:true
-    # Cap total memory+swap at the same value so a memory-pressure attack cannot
-    # spill the node's working set into host swap. Docker would otherwise allow
-    # 2x the memory limit in swap (8G on a 4G-limit node).
-    memswap_limit: 4G
+    # Cap total memory+swap with one knob so they always stay equal: a
+    # memory-pressure attack cannot spill the node's working set into host swap
+    # (Docker would otherwise allow 2x the memory limit in swap), at any value.
+    # On hosts with more RAM, raise CUPRATE_MEM_LIMIT — the node's fjall/jemalloc
+    # budget and the page-cache window for chain data scale with it. The shipped
+    # config's `target_max_memory` should stay at or under this value.
+    memswap_limit: ${CUPRATE_MEM_LIMIT:-4G}
     deploy:
       resources:
         limits:
-          memory: 4G
+          memory: ${CUPRATE_MEM_LIMIT:-4G}
           # Bound the process count as a cheap backstop against fork/connection storms.
-          pids: 512
+          pids: ${CUPRATE_PIDS_LIMIT:-512}
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
## Summary

Addresses two issues found in an adversarial security review of this Docker image's packaging (the host-write bind-mount primitive and the disk-write amplification via debug file logging). This branch stacks directly on `port-monerod-improvements` (i.e. the changes in #36), so merge #36 first and this PR reduces to exactly the new hardening work below.

## Changes

### Runtime hardening (docker-compose.yml)

The container runs as `cuprate` **uid 1000** — the same uid as a great many host users — and previously mounted `./config` **read-write**, meaning a compromised node could write straight into the host's config directory (verified end-to-end on a live deployment). The default Compose file now contains a compromised node:

- `read_only: true` root filesystem, with tmpfs for `/tmp` and the cache dir (`/home/cuprate/.cache/cuprate`, uid/gid 1000, size-bounded). The cache is safely ephemeral per [Cuprate's own docs](https://user.cuprate.org).
- `./config` mounted **read-only** — config is read-only for the node anyway; this removes the host-write path.
- `cap_drop: [ALL]` — cuprated binds only ports > 1024 and needs no capabilities.
- `security_opt: no-new-privileges:true`.
- `pids_limit: 512` and `memswap_limit: 4G` (equal to the memory limit) so a memory-pressure attack cannot spill the node's working set into host swap (Docker would otherwise allow 2x the limit).

### Image hardening (Dockerfile)

The Debian runtime base ships setuid-root helpers (`mount`, `su`, `passwd`, …). Strip their setuid/setgid bits in the runtime stage (`chmod`, not delete, so packages stay intact) so no helper in the image can ever yield root after a compromise — defense in depth under `no-new-privileges`.

### Log amplification (config + docs)

`[tracing.file] level` was left at `debug` (upstream default `info`), which — combined with the RPC server's request-level tracing and the publicly published `18089` — wrote ~400 bytes to the host-backed `cuprate-data` volume **per public RPC request** (measured: 2,000 requests → ~850 KiB). File logging now stays at `info` (per-request traces are debug-only), and the README documents log location, rotation (7 daily files), and disk impact. (The `debug -> info` config change is in `cc8a71e` of the stacked branch; the README note is added here.)

## Verification (live, against a freshly built image on a test host)

All tests ran on a real deployment (built `cuprated` from the pinned commit, deployed with this Compose file, resumed an existing synced chain):

- Container reaches **healthy**, serves restricted RPC, follows the chain (height advanced across the test window).
- `docker inspect`: `ReadonlyRootfs=true`, `CapDrop=[ALL]`, `SecurityOpt=[no-new-privileges:true]`, `PidsLimit=512`, `MemorySwap=4294967296`; config mount `ro`; tmpfs mounted `uid=1000,gid=1000,mode=700,size=64m`.
- In-container: `find / -perm /4000|/2000` → **0 matches**; `NoNewPrivs=1`; `CapEff=0`; seccomp active.
- Write probes: `touch /home/cuprate/.config/cuprate/HACKED` → `Read-only file system`; rootfs write → `Read-only file system`. Cache (address book → `cache/addressbook/ClearNet`) and `/tmp` writes work.
- `docker restart` → comes back **healthy**; no permission errors in logs.
- Log amplification: **3,000 public RPC requests → 0 bytes** of additional log data (was ~388 B/req before).
- Bare `docker run` (the #36 CI smoke-test path) reaches healthy in ~15 s and `--version` reports the pinned commit `318c2dea4eb404ac4ecf2bea87c1a4696b0198cc`.

## Notes / trade-offs

- The peer **address book now lives in the tmpfs cache** (ephemeral across container recreation). Cuprate documents the cache as safely deletable; the node rebuilds its peer list from seeds after a recreate.
- The hardening applies to the Compose deployment; a bare `docker run` gets only the image-level hardening (the README notes the equivalent flags).
- Restricting the *public* `18089` exposure (bind to localhost / firewall) remains operator policy — see the existing README "Docker port publishing and UFW" note.